### PR TITLE
Added a check for d-tube embedding

### DIFF
--- a/src/app/components/cards/MarkdownViewer.jsx
+++ b/src/app/components/cards/MarkdownViewer.jsx
@@ -164,6 +164,22 @@ class MarkdownViewer extends Component {
                             />
                         </div>
                     );
+                } else if (type === 'd-tube') {
+                    const url = `https://d.tube/#!/v/syndicateframes/${id}`;
+                    sections.push(
+                        <div className="videoWrapper">
+                            <iframe
+                                key={idx++}
+                                src={url}
+                                width={w}
+                                height={h}
+                                frameBorder="0"
+                                webkitallowfullscreen
+                                mozallowfullscreen
+                                allowFullScreen
+                            />
+                        </div>
+                    );
                 } else {
                     console.error('MarkdownViewer unknown embed type', type);
                 }


### PR DESCRIPTION
Added a new branch to the drag/drop handler in the Markdown editor to accommodate embedding D-Tube video